### PR TITLE
Ubuntu image updated

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
       # with:


### PR DESCRIPTION
Ubuntu image updated from `ubuntu-18.04` to `ubuntu-22.04`, as `18.04` is no longer supported by GitHub actions